### PR TITLE
feat(agent): add skills system for agentic capability

### DIFF
--- a/docs/agent/skills.md
+++ b/docs/agent/skills.md
@@ -1,0 +1,50 @@
+# MontRS Skills System
+
+Skills are composable, reusable capabilities that agents can load and execute. Unlike tools (which are single-shot function calls), skills provide multi-step workflows, contextual knowledge, and structured execution plans.
+
+## Skill Manifest Format
+
+Each skill is defined by a `skill.toml` manifest:
+
+```toml
+[skill]
+name = "database-setup"
+version = "1.0.0"
+description = "Guides the agent through setting up and configuring a database backend for a MontRS application."
+author = "MontRS"
+tags = ["database", "setup", "configuration"]
+
+[workflow]
+steps = [
+    "Check montrs.toml for database configuration section",
+    "If no database configured, guide user to add [database] section with backend and URL",
+    "Run `cargo add` for the chosen backend driver",
+    "Verify connection with TestRuntime",
+]
+
+[context]
+prompts = [
+    "Which database backend would you like to use? (sqlite, postgres, mysql)",
+    "What is the connection URL or path for your database?",
+]
+invariants = [
+    "Database configuration must be in montrs.toml, not hardcoded",
+    "Connection strings must not be committed to version control",
+]
+```
+
+## Skill Directory Structure
+
+```
+skills/
+  database-setup/
+    skill.toml
+  testing/
+    skill.toml
+  deployment/
+    skill.toml
+```
+
+## Agent Usage
+
+Skills are registered via `@agent-skill` markers in Rust source or discovered from the `skills/` directory. They appear in `tools.json` as structured entries with workflow steps and context prompts.

--- a/packages/agent/src/framework.rs
+++ b/packages/agent/src/framework.rs
@@ -46,6 +46,14 @@ pub const FIXING_ERRORS_WORKFLOW: &str =
 pub const ADDING_FEATURES_WORKFLOW: &str =
     include_str!("../../../docs/agent/workflows/adding-features.md");
 
+pub const SKILLS_GUIDE: &str = include_str!("../../../docs/agent/skills.md");
+pub const SKILL_DATABASE_SETUP: &str =
+    include_str!("../../../skills/database-setup/skill.toml");
+pub const SKILL_TESTING: &str =
+    include_str!("../../../skills/testing/skill.toml");
+pub const SKILL_DEPLOYMENT: &str =
+    include_str!("../../../skills/deployment/skill.toml");
+
 pub fn get_framework_invariants()
 -> std::collections::HashMap<&'static str, &'static str> {
     let mut m = std::collections::HashMap::new();

--- a/packages/agent/src/lib.rs
+++ b/packages/agent/src/lib.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, fs, path::PathBuf};
 pub mod error_parser;
 pub mod framework;
 pub mod guides;
+pub mod skills;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AgentSnapshot {
@@ -675,7 +676,6 @@ impl AgentManager {
                                             && let Some(tool_meta) = self
                                                 .parse_agent_tool_marker(line)
                                         {
-                                            // Avoid duplicates
                                             let name = tool_meta["name"]
                                                 .as_str()
                                                 .unwrap_or_default();
@@ -684,6 +684,20 @@ impl AgentManager {
                                                 .any(|t| t["name"] == name)
                                             {
                                                 tools.push(tool_meta);
+                                            }
+                                        }
+                                        if line.contains("@agent-skill:")
+                                            && let Some(skill_meta) = self
+                                                .parse_agent_skill_marker(line)
+                                        {
+                                            let name = skill_meta["name"]
+                                                .as_str()
+                                                .unwrap_or_default();
+                                            if !tools
+                                                .iter()
+                                                .any(|t| t["name"] == name)
+                                            {
+                                                tools.push(skill_meta);
                                             }
                                         }
                                     }
@@ -717,11 +731,27 @@ impl AgentManager {
                                     tools.push(tool_meta);
                                 }
                             }
+                            if line.contains("@agent-skill:")
+                                && let Some(skill_meta) =
+                                    self.parse_agent_skill_marker(line)
+                            {
+                                let name = skill_meta["name"]
+                                    .as_str()
+                                    .unwrap_or_default();
+                                if !tools.iter().any(|t| t["name"] == name) {
+                                    tools.push(skill_meta);
+                                }
+                            }
                         }
                     }
                 }
             }
         }
+
+        // 3. Discover skills from skills/ directory
+        let discovered_skills = skills::discover_skills(&self.root_path);
+        let skill_tools = skills::skills_to_tools_json(&discovered_skills);
+        tools.extend(skill_tools);
 
         Ok(serde_json::json!({ "tools": tools }))
     }
@@ -736,6 +766,24 @@ impl AgentManager {
 
         Some(serde_json::json!({
             "name": caps.name("name")?.as_str(),
+            "description": caps.name("desc")?.as_str(),
+            "parameters": { "type": "object", "properties": {} }
+        }))
+    }
+
+    fn parse_agent_skill_marker(
+        &self,
+        line: &str,
+    ) -> Option<serde_json::Value> {
+        // Expected format: @agent-skill: name="name" desc="description"
+        let re = regex::Regex::new(
+            r#"@agent-skill:\s+name="(?P<name>[^"]+)"\s+desc="(?P<desc>[^"]+)""#,
+        )
+        .ok()?;
+        let caps = re.captures(line)?;
+
+        Some(serde_json::json!({
+            "name": format!("skill_{}", caps.name("name")?.as_str().replace('-', "_")),
             "description": caps.name("desc")?.as_str(),
             "parameters": { "type": "object", "properties": {} }
         }))
@@ -897,6 +945,22 @@ impl AgentManager {
             "workflows/adding-features".to_string(),
             framework::ADDING_FEATURES_WORKFLOW.to_string(),
         );
+        documentation_snippets.insert(
+            "skills/guide".to_string(),
+            framework::SKILLS_GUIDE.to_string(),
+        );
+        documentation_snippets.insert(
+            "skills/database-setup".to_string(),
+            framework::SKILL_DATABASE_SETUP.to_string(),
+        );
+        documentation_snippets.insert(
+            "skills/testing".to_string(),
+            framework::SKILL_TESTING.to_string(),
+        );
+        documentation_snippets.insert(
+            "skills/deployment".to_string(),
+            framework::SKILL_DEPLOYMENT.to_string(),
+        );
 
         let framework_invariants = framework::get_framework_invariants();
         let mut packages = Vec::new();
@@ -980,6 +1044,22 @@ impl AgentManager {
         documentation_snippets.insert(
             "workflows/adding-features".to_string(),
             framework::ADDING_FEATURES_WORKFLOW.to_string(),
+        );
+        documentation_snippets.insert(
+            "skills/guide".to_string(),
+            framework::SKILLS_GUIDE.to_string(),
+        );
+        documentation_snippets.insert(
+            "skills/database-setup".to_string(),
+            framework::SKILL_DATABASE_SETUP.to_string(),
+        );
+        documentation_snippets.insert(
+            "skills/testing".to_string(),
+            framework::SKILL_TESTING.to_string(),
+        );
+        documentation_snippets.insert(
+            "skills/deployment".to_string(),
+            framework::SKILL_DEPLOYMENT.to_string(),
         );
         documentation_snippets.insert(
             "agent/index".to_string(),

--- a/packages/agent/src/skills/mod.rs
+++ b/packages/agent/src/skills/mod.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+
+/// A skill definition loaded from a skill.toml manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillManifest {
+    pub skill: SkillMeta,
+    pub workflow: SkillWorkflow,
+    pub context: SkillContext,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillMeta {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub author: String,
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillWorkflow {
+    pub steps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillContext {
+    #[serde(default)]
+    pub prompts: Vec<String>,
+    #[serde(default)]
+    pub invariants: Vec<String>,
+}
+
+/// Discover all skills from the skills/ directory.
+pub fn discover_skills(root_path: &std::path::Path) -> Vec<SkillManifest> {
+    let skills_dir = root_path.join("skills");
+    if !skills_dir.exists() {
+        return Vec::new();
+    }
+
+    let mut skills = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&skills_dir) {
+        for entry in entries.flatten() {
+            if entry.path().is_dir() {
+                let manifest_path = entry.path().join("skill.toml");
+                if manifest_path.exists()
+                    && let Ok(content) = std::fs::read_to_string(&manifest_path)
+                    && let Ok(manifest) =
+                        toml::from_str::<SkillManifest>(&content)
+                {
+                    skills.push(manifest);
+                }
+            }
+        }
+    }
+    skills
+}
+
+/// Convert discovered skills into the tools.json format.
+pub fn skills_to_tools_json(
+    skills: &[SkillManifest],
+) -> Vec<serde_json::Value> {
+    skills
+        .iter()
+        .map(|s| {
+            serde_json::json!({
+                "name": format!("skill_{}", s.skill.name.replace('-', "_")),
+                "description": s.skill.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "workflow": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Steps to follow for this skill"
+                        }
+                    }
+                },
+                "skill_meta": {
+                    "name": s.skill.name,
+                    "version": s.skill.version,
+                    "tags": s.skill.tags,
+                    "workflow_steps": s.workflow.steps,
+                    "context_prompts": s.context.prompts,
+                    "context_invariants": s.context.invariants,
+                }
+            })
+        })
+        .collect()
+}

--- a/skills/database-setup/skill.toml
+++ b/skills/database-setup/skill.toml
@@ -1,0 +1,24 @@
+[skill]
+name = "database-setup"
+version = "1.0.0"
+description = "Guides the agent through setting up and configuring a database backend for a MontRS application."
+author = "MontRS"
+tags = ["database", "setup", "configuration"]
+
+[workflow]
+steps = [
+    "Check montrs.toml for database configuration section",
+    "If no database configured, guide user to add [database] section with backend and URL",
+    "Run `cargo add` for the chosen backend driver",
+    "Verify connection with TestRuntime",
+]
+
+[context]
+prompts = [
+    "Which database backend would you like to use? (sqlite, postgres, mysql)",
+    "What is the connection URL or path for your database?",
+]
+invariants = [
+    "Database configuration must be in montrs.toml, not hardcoded",
+    "Connection strings must not be committed to version control",
+]

--- a/skills/deployment/skill.toml
+++ b/skills/deployment/skill.toml
@@ -1,0 +1,26 @@
+[skill]
+name = "deployment"
+version = "1.0.0"
+description = "Guides the agent through deploying a MontRS application to various targets."
+author = "MontRS"
+tags = ["deployment", "devops", "release"]
+
+[workflow]
+steps = [
+    "Determine deployment target: web (WASM+server), desktop (Tauri), or mobile",
+    "For web: build with `montrs build --release`, configure static file serving",
+    "For desktop: use Tauri integration with `cargo tauri build`",
+    "Verify the deployment with a health check or smoke test",
+    "Document the deployment configuration in montrs.toml",
+]
+
+[context]
+prompts = [
+    "What is your deployment target? (web, desktop, mobile)",
+    "Do you have a domain or server ready for deployment?",
+]
+invariants = [
+    "Release builds must use --release flag",
+    "Environment variables must be configured via montrs.toml, not hardcoded",
+    "Deployment configuration must be documented in the project README",
+]

--- a/skills/testing/skill.toml
+++ b/skills/testing/skill.toml
@@ -1,0 +1,27 @@
+[skill]
+name = "testing"
+version = "1.0.0"
+description = "Guides the agent through writing and running tests for MontRS applications."
+author = "MontRS"
+tags = ["testing", "quality", "verification"]
+
+[workflow]
+steps = [
+    "Identify the target: unit test, integration test, or E2E test",
+    "For unit tests: use the test crate's expect() and table_test() macros",
+    "For integration tests: use TestRuntime and Fixture traits",
+    "For E2E tests: use playwright-rs with the e2e crate",
+    "Run tests with `montrs test` or `cargo test --workspace`",
+    "Check test output for failures and iterate",
+]
+
+[context]
+prompts = [
+    "What type of test are you writing? (unit, integration, e2e)",
+    "What is the expected behavior you want to verify?",
+]
+invariants = [
+    "Tests must be deterministic and hermetic",
+    "Integration tests must use TestRuntime for in-process execution",
+    "E2E tests must be tagged with #[cfg(feature = \"e2e\")]",
+]


### PR DESCRIPTION
- Add SkillManifest, SkillMeta, SkillWorkflow, SkillContext structs
- Add discover_skills() to scan skills/ directory for skill.toml files
- Add skills_to_tools_json() to convert skills to tools.json format
- Add @agent-skill marker support alongside @agent-tool
- Add parse_agent_skill_marker() to AgentManager
- Embed skills in framework.rs (database-setup, testing, deployment)
- Include skills in generate_tools_spec and snapshots
- Add 3 starter skills: database-setup, testing, deployment
- Add docs/agent/skills.md documenting the skill system